### PR TITLE
Reduce number of points in data set.

### DIFF
--- a/nl_analyzer.py
+++ b/nl_analyzer.py
@@ -56,8 +56,8 @@ st.sidebar.write(msg)
 st.sidebar.write("---")
 
 msg = """
-If you find anything broken or notice any inaccuracies here, please [open an issue](https://github.com/ehmatthes/nl_analyzer) and I'll be happy to address it.
+If you find anything broken or notice any inaccuracies here, please [open an issue](https://github.com/ehmatthes/nl_analyzer/issues) and I'll be happy to address it.
 
-I'm also happy to hear any [feedback](https://github.com/ehmatthes/nl_analyzer) about how this has helped you decide which platform to use, or any suggestions for what might be more helpful. 
+I'm also happy to hear any [feedback](https://github.com/ehmatthes/nl_analyzer/issues) about how this has helped you decide which platform to use, or any suggestions for what might be more helpful. 
 """
 st.sidebar.write(msg)

--- a/nl_config.py
+++ b/nl_config.py
@@ -42,7 +42,7 @@ class NLConfig:
     # Fig size is 6.4x4, so 6.4" * 200dpi -> 1280 pixels per chart.
     # Use of int makes this fairly approximate, but aiming for order of magnitude.
     # That uses too much data, so actually using a fraction of 1280.
-    num_points = 1280
+    num_points = 256
 
     # font sizes
     fs_brand_label: int = 10

--- a/nl_config.py
+++ b/nl_config.py
@@ -39,6 +39,11 @@ class NLConfig:
 
     aspect_ratio: float = 2.0
 
+    # Fig size is 6.4x4, so 6.4" * 200dpi -> 1280 pixels per chart.
+    # Use of int makes this fairly approximate, but aiming for order of magnitude.
+    # That uses too much data, so actually using a fraction of 1280.
+    num_points = 1280
+
     # font sizes
     fs_brand_label: int = 10
 

--- a/pricer.py
+++ b/pricer.py
@@ -16,9 +16,7 @@ class Pricer:
 
     def _initialize_data(self):
         """Build the dataframe that will be used throughout class."""
-        # Fig size is 6.4x4, so 6.4" * 200dpi -> 1280 pixels per chart.
-        # Use of int makes this fairly approximate, but aiming for order of magnitude.
-        step_size = int(self.nl_config.max_subs / 1280)
+        step_size = int(self.nl_config.max_subs / self.nl_config.num_points)
         if step_size == 0:
             step_size = 1
 


### PR DESCRIPTION
Was using 1280 data points, which uses about 97kb with the default two platforms selected. Dropping to 256 data points, which is the best balance of quality and data footprint. Drops to 17.0kb on first load of compare page. That's 17.5% of the 1280-point plots, and 8.9% of the pre-optimization footprint, with 1280 data points and all platforms selected.

This should handle about 10x as many concurrent users as it would previously handle, although that depends how many select additional platforms, and where the sliders are. It's also significantly more CPU-efficient. With all platforms selected, it's at 35.0kb, which is 18% of the original footprint.